### PR TITLE
Docs: Fix docstring grammar

### DIFF
--- a/pytvpaint/project.py
+++ b/pytvpaint/project.py
@@ -69,7 +69,7 @@ class Project(Refreshable, Renderable):
         """The project's position in the project tabs.
 
         Note:
-            the indices are go from right to left in the UI
+            the indices go from right to left in the UI
         """
         for pos, project_id in enumerate(self.open_projects_ids()):
             if project_id == self.id:


### PR DESCRIPTION
Fix the docstring grammar.

I believe this docstring is also used in the docs here: https://brunchstudio.github.io/pytvpaint/api/objects/project/