### PR TITLE
`tv_background_set` signature change

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -11,10 +11,10 @@ time to do so yet. If you want to contribute on this, please open an issue or a 
 
 ## TVPaint 11.5+
 
-TVPaint 11.5 is minimum supported version simply because we does currently have an older version of TVPaint. The TVPaint 
+TVPaint 11.5 is minimum supported version simply because we currently do not have an older version of TVPaint. The TVPaint 
 SDK is what really limits the compatibility, but we suspect PyTVPaint is also compatible with TVPaint 11 since the SDK 
-hasn't changed in a while. If you have a version of TVPaint prior to 11.5 and want to test to the API, please let us 
-know it works and we will update the minimum requirements for teh plugin and API. 
+hasn't changed in a while. If you have a version of TVPaint prior to 11.5 and want to test the API, please let us 
+know if it works and we will update the minimum requirements for the plugin and API. 
 
 ## Control characters in George results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ extend-select = [
     "D",
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D"]
 

--- a/pytvpaint/george/grg_project.py
+++ b/pytvpaint/george/grg_project.py
@@ -78,14 +78,18 @@ def tv_background_get() -> (
 
 
 def tv_background_set(
-    mode: BackgroundMode, c1: RGBColor | None = None, c2: RGBColor | None = None
+    mode: BackgroundMode,
+    color: tuple[RGBColor, RGBColor] | RGBColor | None = None,
 ) -> None:
     """Set the background mode of the project."""
     args = []
-    if mode == BackgroundMode.CHECK and c1 and c2:
+
+    if mode == BackgroundMode.CHECK and isinstance(color, tuple):
+        c1, c2 = color
         args = [c1.r, c1.g, c1.b, c2.r, c2.g, c2.b]
-    elif mode == BackgroundMode.COLOR and c1:
-        args = [c1.r, c1.g, c1.b]
+    elif mode == BackgroundMode.COLOR and isinstance(color, RGBColor):
+        args = [color.r, color.g, color.b]
+
     send_cmd("tv_Background", mode.value, *args)
 
 

--- a/pytvpaint/project.py
+++ b/pytvpaint/project.py
@@ -264,11 +264,10 @@ class Project(Refreshable, Renderable):
     @set_as_current
     def background_colors(
         self,
-        colors: george.RGBColor | tuple[george.RGBColor, george.RGBColor],
+        colors: tuple[george.RGBColor, george.RGBColor] | george.RGBColor,
     ) -> None:
-        if isinstance(colors, george.RGBColor):
-            colors = (colors,)
-        george.tv_background_set(self.background_mode, *colors)
+        colors_args = colors if isinstance(colors, tuple) else [colors]
+        george.tv_background_set(self.background_mode, *colors_args)
 
     @set_as_current
     def clear_background(self) -> None:

--- a/pytvpaint/utils.py
+++ b/pytvpaint/utils.py
@@ -337,7 +337,7 @@ def render_context(
     # Save the current state
     pre_alpha_save_mode = george.tv_alpha_save_mode_get()
     pre_save_format, pre_save_args = george.tv_save_mode_get()
-    pre_background_mode, colors = george.tv_background_get()
+    pre_background_mode, pre_background_colors = george.tv_background_get()
 
     # Set the save mode values
     if alpha_mode:
@@ -365,8 +365,7 @@ def render_context(
     if save_format:
         george.tv_save_mode_set(pre_save_format, *pre_save_args)
     if background_mode:
-        colors = [colors] if colors else []
-        george.tv_background_set(pre_background_mode, *colors)
+        george.tv_background_set(pre_background_mode, pre_background_colors)
 
     # Restore the layer visibility
     if layers_visibility:

--- a/pytvpaint/utils.py
+++ b/pytvpaint/utils.py
@@ -85,7 +85,7 @@ class Removable(Refreshable):
         """Checks if the object is removed by trying to refresh its data.
 
         Returns:
-            bool: wether if it was removed or not
+            bool: whether if it was removed or not
         """
         self._is_removed = False
         with contextlib.suppress(Exception):

--- a/tests/george/test_grg_project.py
+++ b/tests/george/test_grg_project.py
@@ -73,22 +73,20 @@ COLORS = [RGBColor(255, 0, 0), RGBColor(0, 255, 0), RGBColor(0, 0, 255)]
 @pytest.mark.parametrize(
     "mode, colors",
     [
-        *[(BackgroundMode.COLOR, [c]) for c in COLORS],
-        *[(BackgroundMode.CHECK, [*cs]) for cs in itertools.combinations(COLORS, 2)],
-        (BackgroundMode.NONE, (None,)),
+        *[(BackgroundMode.COLOR, c) for c in COLORS],
+        *[(BackgroundMode.CHECK, cs) for cs in itertools.combinations(COLORS, 2)],
+        (BackgroundMode.NONE, None),
     ],
 )
-def test_tv_background(mode: BackgroundMode, colors: list[RGBColor | None]) -> None:
-    tv_background_set(mode, *colors)
+def test_tv_background(
+    mode: BackgroundMode, colors: tuple[RGBColor, RGBColor] | RGBColor | None
+) -> None:
+    tv_background_set(mode, colors)
 
     current_mode, current_colors = tv_background_get()
 
     assert mode == current_mode
-    assert (
-        colors == tuple(current_colors)
-        if isinstance(current_colors, list)
-        else (current_colors,)
-    )
+    assert current_colors == colors
 
     # reset color
     tv_background_set(BackgroundMode.COLOR, RGBColor(255, 255, 255))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -226,9 +226,9 @@ def test_project_set_background_checker_colors(
     test_project_obj.background_mode = george.BackgroundMode.CHECK
     test_project_obj.background_colors = colors
 
-    mode, colors = george.tv_background_get()
+    mode, actual_colors = george.tv_background_get()
     assert test_project_obj.background_mode == mode
-    assert test_project_obj.background_colors == colors
+    assert test_project_obj.background_colors == actual_colors
 
 
 @pytest.mark.parametrize("header", ["", "Hello", "THis is a project header"])


### PR DESCRIPTION
Simplify the `tv_background_set` signature to accept `tuple[RGBColor, RGBColor] | RGBColor | None` so it's coherent with the `tv_background_get` function.