### PR TITLE
Use kwargs for `tv_setactiveshape` parameters

### DIFF
--- a/pytvpaint/george/grg_base.py
+++ b/pytvpaint/george/grg_base.py
@@ -967,14 +967,14 @@ def tv_get_active_shape() -> TVPShape:
     return tv_cast_to_type(send_cmd("tv_GetActiveShape"), TVPShape)
 
 
-def tv_set_active_shape(shape: TVPShape, *shape_args: Any) -> None:
+def tv_set_active_shape(shape: TVPShape, **shape_kwargs: Any) -> None:
     """Set the current shape and its tool parameters.
 
     Args:
         shape: the shape to set
-        *shape_args: the shape specific parameters
+        **shape_kwargs: the shape specific parameters as keyword arguments
     """
-    send_cmd("tv_SetActiveShape", shape.value, *shape_args)
+    send_cmd("tv_SetActiveShape", shape.value, *args_dict_to_list(shape_kwargs))
 
 
 @overload

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def count_up_generate(test_clip_obj: Clip) -> None:
         send_cmd("tv_TextTool2", "size", 200)  # set text size
         george.tv_text_brush(str(i))  # set the brush text
         george.tv_set_active_shape(
-            george.TVPShape.FREE_HAND_LINE, "size", 200
+            george.TVPShape.FREE_HAND_LINE, size=200
         )  # set the shape and it's size
         # write a line with the text brush, having the start-end pos being the same will fake a single click
         george.tv_line(text_pos, text_pos)


### PR DESCRIPTION
For the [`tv_set_active_shape`](https://www.tvpaint.com/doc/tvpaint-animation-11/george-commands#tv_setactiveshape) function, if you want to set the shape parameters you need to do that:

```python
george.tv_set_active_shape(george.TVPShape.RECTANGLE, "aaliasing", 0)
```

With the fix, using kwargs is more pythonic:

```python
george.tv_set_active_shape(george.TVPShape.RECTANGLE, aaliasing=0)
```

(reported by @kstrandli)