### PR TITLE
fix(CameraPoint): undefined attribute in scale setter

### DIFF
--- a/pytvpaint/camera.py
+++ b/pytvpaint/camera.py
@@ -264,9 +264,9 @@ class CameraPoint(Removable):
 
     @scale.setter
     def scale(self, value: float) -> None:
-        current_data = george.tv_camera_enum_points(self.id)
+        current_data = george.tv_camera_enum_points(self.index)
         george.tv_camera_set_point(
-            self.id,
+            self.index,
             x=current_data.x,
             y=current_data.y,
             angle=current_data.angle,


### PR DESCRIPTION
- Fixed an undefined attribute in the scale setter of the `CameraPoint` class
  - `self.id` -> `self.index`

Issue #17